### PR TITLE
Runtime variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,32 @@ interface ProjectLaunchConfig {
         { "name": "Build server", "cmd": "npm run build-server:dev", "groups": ["dev"] },
         { "name": "Lint frontend", "cmd": "npm run lint-frontend:dev", "groups": ["lint", "test"] },
         { "name": "Lint server", "cmd": "npm run lint-server:dev", "groups": ["lint", "test"] },
+        { "name": "Command with runtime var", "cmd": "echo $1" },
         { "name": "Test", "cmd": "npm test", "groups": ["test"] }
     ]
 }
 ```
+### Runtime Launch Variables
+Sometimes you may need to frequently run the same type of command where only one argument changes.
+####Examples:
+```
+node ./install.js --env test
+```
+```
+node ./install.js --env dev
+```
+```
+node ./install.js --env prod
+```
+Instead of creating three separate entries in your .projectlaunch.json config, you can put a variable in one command like so.
+```
+{ "name": "Install with runtime var", "cmd": "node ./install.js --env $1" }
+```
+When you start a command that contains $1, Project Launch will prompt you to enter the value of the variable before it runs the command. 
+####Multiple Variables
+Project Launch supports prompting and setting up to five runtime variables ($1, $2, $3, $4, $5).
 
-### Example configuration
+### Example lua configuration
 
 ```lua
 

--- a/lua/projectlaunch/jobs.lua
+++ b/lua/projectlaunch/jobs.lua
@@ -5,7 +5,12 @@ local api = vim.api
 local term_name_prefix = "ProjectLaunch terminal - "
 
 local Job = {}
+runtimeVars = {}
+
 function Job:new(command, opts)
+    runtimeVars = {}
+    local finalCommand = generateCommand(command)
+	
 	local temp_win, buf = win.create_temp_window()
 	vim.opt_local.spell = false
 
@@ -20,8 +25,8 @@ function Job:new(command, opts)
 		-- duplicating the name lets commands be edited and
 		-- jobs won't get the updated command until it's rerun,
 		-- so it won't look like the newly edited command had been run automatically
-		name = command.name,
-		cmd = command.cmd,
+		name = generateJobName(command),
+		cmd = finalCommand,
 		job_id = nil,
 		buf = buf,
 		running = true,
@@ -30,7 +35,7 @@ function Job:new(command, opts)
 		_args = { command, opts },
 	}
 
-	j.job_id = vim.fn.termopen(vim.split(command.cmd, " "), {
+	j.job_id = vim.fn.termopen(vim.split(finalCommand, " "), {
 		cwd = cwd,
 		on_exit = function(_, exit_code)
 			j.running = false
@@ -55,4 +60,53 @@ function Job:kill()
 	vim.fn.jobstop(self.job_id)
 end
 
+function generateCommand(originalCommand) 
+	local finalCommand = originalCommand.cmd 
+
+    for i = 1,5,1
+    do
+        local substitutionString = "$" .. i
+
+        if string.find(originalCommand.cmd, substitutionString) then
+            setRuntimeVarViaPrompt(substitutionString, finalCommand)
+            finalCommand = string.gsub(finalCommand, substitutionString, runtimeVars[i])
+        end
+    end
+
+    return finalCommand
+end
+
+function generateJobName(command) 
+    if(table.getn(runtimeVars) > 0) then
+       local args = "" 
+       
+       for key, value in pairs(runtimeVars) do
+          args = args .. value .. "," 
+       end 
+
+       args = args:sub(1, -2) --Remove trailing comma
+
+       return command.name .. " (" .. args .. ")"
+    end 
+
+    return command.name
+end
+
+
+function setRuntimeVarViaPrompt(var, command)
+    vim.ui.input({ prompt = "ProjectLaunch: Enter argument " .. var .. " for\n" .. command .. "\n:"}, function(input)
+        table.insert(runtimeVars, input) 
+    end)
+end
+
+
+function replaceVariableInCommand(var, finalCommand)
+    vim.ui.input({ prompt = "ProjectLaunch: Enter argument " .. var .. ": "}, function(cmd)
+        finalCommand = string.gsub(finalCommand, var, cmd)
+    end)
+
+    return finalCommand
+end
+
 return Job
+

--- a/lua/projectlaunch/jobs.lua
+++ b/lua/projectlaunch/jobs.lua
@@ -8,7 +8,8 @@ local term_name_prefix = "ProjectLaunch terminal - "
 local Job = {}
 
 function Job:new(command, opts)
-	local finalCommand = runtimeVarManager.interpolate(command)
+	local runtimeVars = runtimeVarManager.prompt(command)
+	local finalCommand = runtimeVarManager.interpolate(command, runtimeVars)
 
 	local temp_win, buf = win.create_temp_window()
 	vim.opt_local.spell = false
@@ -24,7 +25,7 @@ function Job:new(command, opts)
 		-- duplicating the name lets commands be edited and
 		-- jobs won't get the updated command until it's rerun,
 		-- so it won't look like the newly edited command had been run automatically
-		name = runtimeVarManager.generateJobName(command),
+		name = runtimeVarManager.generateJobName(command, runtimeVars),
 		cmd = finalCommand,
 		job_id = nil,
 		buf = buf,

--- a/lua/projectlaunch/jobs.lua
+++ b/lua/projectlaunch/jobs.lua
@@ -68,7 +68,7 @@ function generateCommand(originalCommand)
         local substitutionString = "$" .. i
 
         if string.find(originalCommand.cmd, substitutionString) then
-            setRuntimeVarViaPrompt(substitutionString, finalCommand)
+            setRuntimeVarViaPrompt(i, finalCommand)
             finalCommand = string.gsub(finalCommand, substitutionString, runtimeVars[i])
         end
     end
@@ -76,37 +76,40 @@ function generateCommand(originalCommand)
     return finalCommand
 end
 
-function generateJobName(command) 
-    if(table.getn(runtimeVars) > 0) then
-       local args = "" 
-       
-       for key, value in pairs(runtimeVars) do
-          args = args .. value .. "," 
-       end 
-
-       args = args:sub(1, -2) --Remove trailing comma
-
-       return command.name .. " (" .. args .. ")"
+function generateJobName(command)
+    if(getTableSize(runtimeVars) > 0) then
+       return command.name .. createArgPrefix()
     end 
 
     return command.name
 end
 
+function createArgPrefix()
+    local args = ""
 
-function setRuntimeVarViaPrompt(var, command)
-    vim.ui.input({ prompt = "ProjectLaunch: Enter argument " .. var .. " for\n" .. command .. "\n:"}, function(input)
-        table.insert(runtimeVars, input) 
-    end)
+    for key, value in pairs(runtimeVars) do
+        args = args .. value .. "," 
+    end 
+
+    args = args:sub(1, -2) --Remove trailing comma
+
+    return " (" .. args .. ")"
+end
+
+function getTableSize(t)
+    local count = 0
+    for _, __ in pairs(t) do
+        count = count + 1
+    end
+    return count
 end
 
 
-function replaceVariableInCommand(var, finalCommand)
-    vim.ui.input({ prompt = "ProjectLaunch: Enter argument " .. var .. ": "}, function(cmd)
-        finalCommand = string.gsub(finalCommand, var, cmd)
+function setRuntimeVarViaPrompt(i, command)
+    substitutionString = "$" .. i
+    vim.ui.input({ prompt = "ProjectLaunch: Enter argument " .. substitutionString .. " for\n" .. command .. "\n:"}, function(input)
+        runtimeVars[i] = input 
     end)
-
-    return finalCommand
 end
 
 return Job
-

--- a/lua/projectlaunch/runtime_variable_manager.lua
+++ b/lua/projectlaunch/runtime_variable_manager.lua
@@ -1,37 +1,44 @@
 local RuntimeVarManager = {}
-local vars = {}
+local varLimit = 5
+local varPrefix = "$"
 
-local function createArgSuffix()
+local function createArgSuffix(vars)
 	return " (" .. table.concat(vars, ",") .. ")"
 end
 
-local function setRuntimeVarViaPrompt(i, command)
-	local substitutionString = "$" .. i
-	vim.ui.input(
-		{ prompt = "ProjectLaunch: Enter argument " .. substitutionString .. " for\n" .. command .. "\n:" },
-		function(input)
-			vars[i] = input
+function RuntimeVarManager.prompt(command)
+	local vars = {}
+	for i = 1, varLimit, 1 do
+		local substitutionString = varPrefix .. i
+
+		if string.find(command.cmd, substitutionString) then
+			vim.ui.input(
+				{ prompt = "ProjectLaunch: Enter argument " .. substitutionString .. " for\n" .. command.cmd .. "\n:" },
+				function(input)
+					vars[i] = input
+				end
+			)
 		end
-	)
+	end
+
+	return vars
 end
 
-function RuntimeVarManager.generateJobName(command)
+function RuntimeVarManager.generateJobName(command, vars)
 	if vim.tbl_count(vars) > 0 then
-		return command.name .. createArgSuffix()
+		return command.name .. createArgSuffix(vars)
 	end
 
 	return command.name
 end
 
-function RuntimeVarManager.interpolate(originalCommand)
-    vars = {}
+function RuntimeVarManager.interpolate(originalCommand, vars)
 	local finalCommand = originalCommand.cmd
 
-	for i = 1, 5, 1 do
-		local substitutionString = "$" .. i
+	for i = 1, varLimit, 1 do
+		local substitutionString = varPrefix .. i
 
 		if string.find(originalCommand.cmd, substitutionString) then
-			setRuntimeVarViaPrompt(i, finalCommand)
 			finalCommand = string.gsub(finalCommand, substitutionString, vars[i])
 		end
 	end

--- a/lua/projectlaunch/runtime_variable_manager.lua
+++ b/lua/projectlaunch/runtime_variable_manager.lua
@@ -1,0 +1,42 @@
+local RuntimeVarManager = {}
+local vars = {}
+
+local function createArgSuffix()
+	return " (" .. table.concat(vars, ",") .. ")"
+end
+
+local function setRuntimeVarViaPrompt(i, command)
+	local substitutionString = "$" .. i
+	vim.ui.input(
+		{ prompt = "ProjectLaunch: Enter argument " .. substitutionString .. " for\n" .. command .. "\n:" },
+		function(input)
+			vars[i] = input
+		end
+	)
+end
+
+function RuntimeVarManager.generateJobName(command)
+	if vim.tbl_count(vars) > 0 then
+		return command.name .. createArgSuffix()
+	end
+
+	return command.name
+end
+
+function RuntimeVarManager.interpolate(originalCommand)
+    vars = {}
+	local finalCommand = originalCommand.cmd
+
+	for i = 1, 5, 1 do
+		local substitutionString = "$" .. i
+
+		if string.find(originalCommand.cmd, substitutionString) then
+			setRuntimeVarViaPrompt(i, finalCommand)
+			finalCommand = string.gsub(finalCommand, substitutionString, vars[i])
+		end
+	end
+
+	return finalCommand
+end
+
+return RuntimeVarManager


### PR DESCRIPTION
This adds a feature where if you put ($1, $2, $3, $4, or $5) inside a command within .projectlaunch.json, you will be prompted to fill it in at runtime.

This has been very useful for me. I often have similar commands where only one argument changes. This allows me to store only one version of the command in my config rather than having to copy the command ~5 times and create different versions.

If the command had any vars in it, the command name is updated to have () appended with the value of the arguments you sent.