### PR TITLE
Feat/default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ interface ProjectLaunchConfig {
 ```
 ### Runtime Launch Variables
 Sometimes you may need to frequently run the same type of command where only one argument changes.
-####Examples:
+#### Examples:
 ```
 node ./install.js --env test
 ```
@@ -63,7 +63,7 @@ Instead of creating three separate entries in your .projectlaunch.json config, y
 { "name": "Install with runtime var", "cmd": "node ./install.js --env $1" }
 ```
 When you start a command that contains $1, Project Launch will prompt you to enter the value of the variable before it runs the command. 
-####Multiple Variables
+#### Multiple Variables
 Project Launch supports prompting and setting up to five runtime variables ($1, $2, $3, $4, $5).
 
 ### Example lua configuration
@@ -99,6 +99,9 @@ vim.keymap.set('n', "<leader>lm", projectlaunch.show_prev, {noremap = true, expr
 
 -- restart the command running in the currently open split terminal
 vim.keymap.set('n', "<leader>lr", projectlaunch.restart_command_in_split, {noremap = true, expr = false, buffer = false})
+
+-- edit project launch config in a buffer. Generates the config with a default if the file does not exist.
+vim.keymap.set('n', "<leader>le", projectlaunch.edit_config, {noremap = true, expr = false, buffer = false})
 
 -- add custom commands programmatically. you can write your own lua code to add a list of commands
 -- from a tool you use that projectlaunch.nvim doesn't support. or type part of a long command that

--- a/lua/projectlaunch.lua
+++ b/lua/projectlaunch.lua
@@ -27,6 +27,9 @@ M.setup = function(opts)
 	options.override(opts)
 end
 
+--Edit project launch config in a buffer. Generate the config with a default if the file does not exist.
+M.edit_config = config.edit_config
+
 -- pass a command (as a string) to add to the launch menu
 M.add_custom_command = config.add_custom_command
 

--- a/lua/projectlaunch/config.lua
+++ b/lua/projectlaunch/config.lua
@@ -123,8 +123,8 @@ local function file_approximates_format()
 	if file_readable == 0 then
 		vim.notify("Config doesn't exist", vim.log.levels.WARN)
 	else
-		local lines =  vim.fn.readfile(get_config_path())
-		local content = table.concat(lines, '\n')
+		local lines = vim.fn.readfile(get_config_path())
+		local content = table.concat(lines, "\n")
 
 		local has_commands = string.find(content, 'commands"')
 		local has_curly_brace = string.find(content, "{")


### PR DESCRIPTION
New PR because I messed up the git history on the other branch. This new PR uses the vim apis as requested. 

One note on the file_approximates_format function. I tried to go down your suggested path of using JSON decode, but it was too strict and often led to config loss if the edit keymap was used while there was a typo in the config. Only verifying a bare minimum of what is in the config keeps the defaulting logic typo resistant. In summary, I don't want to lose my launch commands if I forgot to add a comma somewhere.

--
Created a new edit_config() function.

Because I have so many different projects, I found myself constantly generating a new .projectlaunch.json file, and I made a vim macro to auto populate a default config structure. I eventually converted that macro into lua code inside my vim config, and I thought I'd like to turn this into a feature of project launch itself.

edit_config() does two things. It checks to see if the project launch config exists. If it already exists and conforms to the appropriate format/interface, it just opens it in a buffer for editing. If the file doesn't exist, it creates the file with a default echo command.
